### PR TITLE
Use filepath.Join for config paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
     "fmt"
     "os"
     "os/exec"
+    "path/filepath"
     "strings"
 
     log "github.com/sirupsen/logrus"
@@ -41,10 +42,10 @@ func GetConfig(name string) *Config {
     if curDir, err = os.Getwd(); err != nil {
         log.Fatal(err)
     }
-    confDir = fmt.Sprintf("%s/appconfig", curDir)
-    logDir = fmt.Sprintf("%s/applogs", curDir)
+    confDir = filepath.Join(curDir, "appconfig")
+    logDir = filepath.Join(curDir, "applogs")
 
-    if _, err := os.Stat(confDir + "/" + name); os.IsNotExist(err) {
+    if _, err := os.Stat(filepath.Join(confDir, name)); os.IsNotExist(err) {
         log.Panicln("Config file not found")
     }
     log.Debug(confDir)
@@ -59,7 +60,7 @@ func GetConfig(name string) *Config {
         viper.Set("LogLocation", logDir)
         viper.Set("TaskForgeAPIURL", "https://api.taskforge.local")
 
-        viper.WriteConfigAs(confDir + "/config.json")
+        viper.WriteConfigAs(filepath.Join(confDir, "config.json"))
     } else {
         log.Debug("Config Loaded")
     }


### PR DESCRIPTION
## Summary
- construct config paths with `filepath.Join`
- import `path/filepath`

## Testing
- `go build ./...` *(fails: proxyconnect tcp: dial tcp 172.21.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683d1519a8608323ba057e8d9c4e8114